### PR TITLE
Generic Datasource Config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,11 +89,6 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>
@@ -121,6 +116,18 @@
         <dependency>
             <groupId>org.springframework.restdocs</groupId>
             <artifactId>spring-restdocs-core</artifactId>
+        </dependency>
+
+        <!-- DB drivers -->
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
     <dependencyManagement>

--- a/src/main/resources/application-cloud.yml
+++ b/src/main/resources/application-cloud.yml
@@ -1,11 +1,12 @@
 spring:
   datasource:
-    driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://${POSTGRESQL_SERVICE_HOST}:${POSTGRESQL_SERVICE_PORT}/${POSTGRESQL_DATABASE}
-    username: ${POSTGRESQL_USER}
-    password: ${POSTGRESQL_PASSWORD}
+    driver-class-name: ${DB_DRIVER_CLASS_NAME}
+    url: ${DB_JDBC_URL}
+  archive-datasource:
+    driver-class-name: ${DB_ARCHIVE_DRIVER_CLASS_NAME}
+    url: ${DB_ARCHIVE_JDBC_URL}
   jpa:
-    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    database-platform: ${DB_HIBERNATE_DIALECT}
 
 management:
   server:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,12 @@ spring:
     name: cwa-quick-test-backend
   datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:log
+    url: jdbc:h2:mem:quicktest
+    username: sa
+    password: ''
+  archive-datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:quicktest-archive
     username: sa
     password: ''
 


### PR DESCRIPTION
Generic datasource config for OpenShift deployment
Add MySql Driver Dependency

Add config for a second datasource for archive database.

Quick Test Backend now supports both PostgreSQL and MySQL.