### PR TITLE
Fix: Wrong Property CatalogName in DB Changelog

### DIFF
--- a/src/main/resources/db/changelog/V001_add_UniqueConstraints.yml
+++ b/src/main/resources/db/changelog/V001_add_UniqueConstraints.yml
@@ -6,4 +6,3 @@ databaseChangeLog:
         - addUniqueConstraint:
             columnNames: short_hashed_guid, poc_id
             tableName: quick_test
-            catalogName: short_hasded_poc


### PR DESCRIPTION
The CatalogName property in the DB changelog prevents the backend to startup when connected to real database.