### PR TITLE
Updated Apache pdfbox to 2.0.24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <keycloak.version>10.0.1</keycloak.version>
         <springdoc.version>1.4.2</springdoc.version>
         <liquibase.version>4.3.2</liquibase.version>
-        <pdfbox.version>2.0.23</pdfbox.version>
+        <pdfbox.version>2.0.24</pdfbox.version>
         <google-zxing.version>3.4.1</google-zxing.version>
         <opencsv.version>5.3</opencsv.version>
         <springTestAddons.version>2.5.2</springTestAddons.version>


### PR DESCRIPTION
Updated Apache pdfbox from 2.0.23 to 2.0.24 with two security updates:

CVE-2021-31811: A carefully crafted PDF file can trigger an OutOfMemory-Exception while loading a tiny file
CVE-2021-31812: A carefully crafted PDF file can trigger an infinite loop while loading the file