### PR TITLE
Alter quicktest-log columns to match quicktest

### DIFF
--- a/src/main/resources/db/changelog.yml
+++ b/src/main/resources/db/changelog.yml
@@ -26,3 +26,6 @@ databaseChangeLog:
   - include:
       file: changelog/V009_add_index.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/V010_change_quickTestLog_column_size.yml
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/V010_change_quickTestLog_column_size.yml
+++ b/src/main/resources/db/changelog/V010_change_quickTestLog_column_size.yml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - changeSet:
+      id: alter-quicktest-log-column-size
+      author: bergmann-dierk
+      changes:
+        - modifyDataType:
+            tableName: quick_test_log
+            columnName: poc_id
+            newDataType: varchar(255)
+
+        - modifyDataType:
+            tableName: quick_test_log
+            columnName: tenant_id
+            newDataType: varchar(255)


### PR DESCRIPTION
Increased column sizes for poc_id and tenant_id in quicktest-log table to match quicktest table.