### PR TITLE
Alter testBrandName column sizes to match possible input

### DIFF
--- a/src/main/resources/db/changelog.yml
+++ b/src/main/resources/db/changelog.yml
@@ -29,3 +29,6 @@ databaseChangeLog:
   - include:
       file: changelog/V010_change_quickTestLog_column_size.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/V011_change_testBrandName_column_size.yml
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/V011_change_testBrandName_column_size.yml
+++ b/src/main/resources/db/changelog/V011_change_testBrandName_column_size.yml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - changeSet:
+      id: alter-quicktest-testBrandName-column-size
+      author: bergmann-dierk
+      changes:
+        - modifyDataType:
+            tableName: quick_test
+            columnName: test_brand_name
+            newDataType: varchar(350)
+
+        - modifyDataType:
+            tableName: quick_test_archive
+            columnName: test_brand_name
+            newDataType: varchar(350)


### PR DESCRIPTION
Max input length for Test Brand Name is 200, due to encryption of the database, the column size for this field needs to be adjusted to a higher value