### PR TITLE
feat: add personal additional info

### DIFF
--- a/src/main/java/app/coronawarn/quicktest/config/PdfConfig.java
+++ b/src/main/java/app/coronawarn/quicktest/config/PdfConfig.java
@@ -63,6 +63,7 @@ public class PdfConfig {
     private String birthDateDescriptionText = "Geburtstag: ";
     private String furtherDataAboutTestDescriptionText = "Weitere Angaben zum Test: ";
     private String executedFromDescriptionText = "Durchgeführt durch: ";
+    private String additionalInfoDescriptionText = "Zusätzliche Informationen: ";
 
     private String certFlagPath = "pdf/eu_flag.png";
     private String certCertlogoPath = "pdf/certificate.png";

--- a/src/main/java/app/coronawarn/quicktest/domain/QuickTest.java
+++ b/src/main/java/app/coronawarn/quicktest/domain/QuickTest.java
@@ -186,6 +186,10 @@ public class QuickTest {
     @Column(name = "dcc_status")
     private DccStatus dccStatus;
 
+    @Column(name = "additional_info")
+    @Convert(converter = DbEncryptionStringConverter.class)
+    private String additionalInfo;
+
     @PrePersist
     private void onCreate() {
         LocalDateTime now = Utilities.getCurrentLocalDateTimeUtc();

--- a/src/main/java/app/coronawarn/quicktest/domain/QuickTestArchive.java
+++ b/src/main/java/app/coronawarn/quicktest/domain/QuickTestArchive.java
@@ -23,7 +23,6 @@ package app.coronawarn.quicktest.domain;
 import app.coronawarn.quicktest.dbencryption.DbEncryptionBooleanConverter;
 import app.coronawarn.quicktest.dbencryption.DbEncryptionByteArrayConverter;
 import app.coronawarn.quicktest.dbencryption.DbEncryptionSexTypeConverter;
-import app.coronawarn.quicktest.dbencryption.DbEncryptionShortConverter;
 import app.coronawarn.quicktest.dbencryption.DbEncryptionStringConverter;
 import app.coronawarn.quicktest.model.SecurityAuditListenerQuickTestArchive;
 import app.coronawarn.quicktest.model.Sex;
@@ -147,4 +146,8 @@ public class QuickTestArchive {
     @Column(name = "dcc")
     @Convert(converter = DbEncryptionStringConverter.class)
     private String dcc;
+
+    @Column(name = "additional_info")
+    @Convert(converter = DbEncryptionStringConverter.class)
+    private String additionalInfo;
 }

--- a/src/main/java/app/coronawarn/quicktest/model/quicktest/QuickTestPersonalDataRequest.java
+++ b/src/main/java/app/coronawarn/quicktest/model/quicktest/QuickTestPersonalDataRequest.java
@@ -107,4 +107,8 @@ public class QuickTestPersonalDataRequest {
     private String testResultServerHash;
 
     private Boolean dccConsent;
+
+    @ValidCommonCharAndNumber
+    @Size(min = 1, max = 250)
+    private String additionalInfo;
 }

--- a/src/main/java/app/coronawarn/quicktest/service/QuickTestService.java
+++ b/src/main/java/app/coronawarn/quicktest/service/QuickTestService.java
@@ -228,6 +228,7 @@ public class QuickTestService {
         quicktest.setDiseaseAgentTargeted(quickTestPersonalData.getDiseaseAgentTargeted());
         quicktest.setTestResultServerHash(quickTestPersonalData.getTestResultServerHash());
         quicktest.setDccConsent(quickTestPersonalData.getDccConsent() != null && quickTestPersonalData.getDccConsent());
+        quicktest.setAdditionalInfo(quickTestPersonalData.getAdditionalInfo());
         try {
             quickTestRepository.saveAndFlush(quicktest);
         } catch (Exception e) {
@@ -295,6 +296,7 @@ public class QuickTestService {
         quickTestArchive.setTestBrandName(quickTest.getTestBrandName());
         quickTestArchive.setPdf(pdf);
         quickTestArchive.setTestResultServerHash(quickTest.getTestResultServerHash());
+        quickTestArchive.setAdditionalInfo(quickTest.getAdditionalInfo());
         return quickTestArchive;
     }
 

--- a/src/main/java/app/coronawarn/quicktest/utils/DccPdfGenerator.java
+++ b/src/main/java/app/coronawarn/quicktest/utils/DccPdfGenerator.java
@@ -20,6 +20,8 @@
 
 package app.coronawarn.quicktest.utils;
 
+import static app.coronawarn.quicktest.utils.PdfUtils.splitStringToParagraph;
+
 import app.coronawarn.quicktest.config.PdfConfig;
 import app.coronawarn.quicktest.domain.QuickTest;
 import com.google.zxing.BarcodeFormat;
@@ -38,7 +40,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -564,18 +565,7 @@ public class DccPdfGenerator {
             float paragraphIndent = 150f;
             cos.newLineAtOffset(paragraphIndent, leftLines * -spacingText);
 
-            int limit = 25;
-            List<String> textParagraph = new ArrayList<>();
-            StringBuilder lineBuilder = new StringBuilder();
-            String[] split = value.split(" ");
-            for (int i = 0, splitLength = split.length; i < splitLength; i++) {
-                String word = split[i];
-                lineBuilder.append(word).append(" ");
-                if (lineBuilder.length() + word.length() > limit || i == splitLength - 1) {
-                    textParagraph.add(lineBuilder.toString());
-                    lineBuilder = new StringBuilder();
-                }
-            }
+            List<String> textParagraph = splitStringToParagraph(value, 25);
             int rightLines = 0;
             for (String n : textParagraph) {
                 cos.showText(n);

--- a/src/main/java/app/coronawarn/quicktest/utils/DccPdfGenerator.java
+++ b/src/main/java/app/coronawarn/quicktest/utils/DccPdfGenerator.java
@@ -565,7 +565,7 @@ public class DccPdfGenerator {
             float paragraphIndent = 150f;
             cos.newLineAtOffset(paragraphIndent, leftLines * -spacingText);
 
-            List<String> textParagraph = splitStringToParagraph(value, 25);
+            List<String> textParagraph = splitStringToParagraph(value, 30);
             int rightLines = 0;
             for (String n : textParagraph) {
                 cos.showText(n);

--- a/src/main/java/app/coronawarn/quicktest/utils/PdfGenerator.java
+++ b/src/main/java/app/coronawarn/quicktest/utils/PdfGenerator.java
@@ -285,9 +285,12 @@ public class PdfGenerator {
         if (quicktest.getTestBrandName() == null) {
             cos.showText(pdfConfig.getTestBrandNameDescriptionText() + pdfConfig.getTradeNameEmptyText());
         } else {
-            cos.showText(pdfConfig.getTestBrandNameDescriptionText() + quicktest.getTestBrandName());
+            cos.showText(pdfConfig.getTestBrandNameDescriptionText());
+            for (String line : splitStringToParagraph(quicktest.getTestBrandName(), 60)) {
+                cos.showText(line);
+                cos.newLine();
+            }
         }
-        cos.newLine();
         String useText = "";
         if (quicktest.getTestResult() != null && quicktest.getTestResult() == positive) {
             useText = pdfConfig.getPositiveInstructionText();

--- a/src/main/java/app/coronawarn/quicktest/utils/PdfGenerator.java
+++ b/src/main/java/app/coronawarn/quicktest/utils/PdfGenerator.java
@@ -21,6 +21,7 @@
 package app.coronawarn.quicktest.utils;
 
 import static app.coronawarn.quicktest.model.Sex.DIVERSE;
+import static app.coronawarn.quicktest.utils.PdfUtils.splitStringToParagraph;
 
 import app.coronawarn.quicktest.config.PdfConfig;
 import app.coronawarn.quicktest.domain.QuickTest;
@@ -262,6 +263,16 @@ public class PdfGenerator {
             cos.showText(pdfConfig.getBirthDateDescriptionText() + datetime.format(formatterDate));
         } else {
             cos.showText(pdfConfig.getBirthDateDescriptionText() + "-");
+        }
+        cos.newLine();
+        if (quicktest.getAdditionalInfo() != null) {
+            cos.newLine();
+            cos.showText(pdfConfig.getAdditionalInfoDescriptionText());
+            cos.newLine();
+            for (String line : splitStringToParagraph(quicktest.getAdditionalInfo(), 80)) {
+                cos.showText(line);
+                cos.newLine();
+            }
         }
         cos.newLine();
         cos.newLine();

--- a/src/main/java/app/coronawarn/quicktest/utils/PdfUtils.java
+++ b/src/main/java/app/coronawarn/quicktest/utils/PdfUtils.java
@@ -1,0 +1,51 @@
+/*-
+ * ---license-start
+ * Corona-Warn-App / cwa-quick-test-backend
+ * ---
+ * Copyright (C) 2021 T-Systems International GmbH and all other contributors
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package app.coronawarn.quicktest.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility class for PDF generation.
+ */
+public final class PdfUtils {
+
+    /**
+     * Split a String by whitespace and return a list of lines with a certain limit.
+     * @param value The String to be split.
+     * @param limit Line limit.
+     * @return List of Strings to be printed as a paragraph.
+     */
+    public static List<String> splitStringToParagraph(String value, int limit) {
+        List<String> textParagraph = new ArrayList<>();
+        StringBuilder lineBuilder = new StringBuilder();
+        String[] split = value.split(" ");
+        for (int i = 0, splitLength = split.length; i < splitLength; i++) {
+            String word = split[i];
+            lineBuilder.append(word).append(" ");
+            if (i == splitLength - 1 || lineBuilder.length() + split[i + 1].length() > limit) {
+                textParagraph.add(lineBuilder.toString());
+                lineBuilder = new StringBuilder();
+            }
+        }
+        return textParagraph;
+    }
+}

--- a/src/main/resources/db/changelog.yml
+++ b/src/main/resources/db/changelog.yml
@@ -38,3 +38,6 @@ databaseChangeLog:
   - include:
       file: changelog/V013_combine_index.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/V014_add_additional_info_column.yml
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/V014_add_additional_info_column.yml
+++ b/src/main/resources/db/changelog/V014_add_additional_info_column.yml
@@ -1,0 +1,19 @@
+databaseChangeLog:
+  - changeSet:
+      id: add-additional-info-columns
+      author: bergmann-dierk
+      changes:
+        - addColumn:
+            tableName: quick_test
+            columns:
+              - column:
+                  name: additional_info
+                  type: varchar(400)
+        - addColumn:
+            tableName: quick_test_archive
+            columns:
+              - column:
+                  name: additional_info
+                  type: varchar(400)
+
+

--- a/src/test/java/app/coronawarn/quicktest/entity/QuickTestArchiveTest.java
+++ b/src/test/java/app/coronawarn/quicktest/entity/QuickTestArchiveTest.java
@@ -20,17 +20,16 @@
 
 package app.coronawarn.quicktest.entity;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import app.coronawarn.quicktest.domain.QuickTestArchive;
 import app.coronawarn.quicktest.model.Sex;
-import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 import java.lang.reflect.Method;
 import java.time.LocalDateTime;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
 
 @Slf4j
 @SpringBootTest
@@ -61,6 +60,7 @@ public class QuickTestArchiveTest {
         quickTestArchive.setPrivacyAgreement(Boolean.FALSE);
         quickTestArchive.setSex(Sex.DIVERSE);
         quickTestArchive.setPdf("Hello".getBytes());
+        quickTestArchive.setAdditionalInfo("Hello");
         assertEquals("QuickTestArchive(hashedGuid=mkamhvdumyvhxeftazravmyrasozuloaghgluvbfjohpofogkylcnsybubamwnht, "
                         + "shortHashedGuid=cjfybkfn, tenantId=4711, pocId=4711-A, createdAt=2021-04-08T08:11:11, "
                         + "updatedAt=2021-04-08T08:11:12, version=null, confirmationCwa=true, testResult=5, "
@@ -68,7 +68,7 @@ public class QuickTestArchiveTest {
                         + "phoneNumber=00491777777777777, sex=DIVERSE, street=Boe, houseNumber=11, zipCode=12345, "
                         + "city=oyvkpigcga, testBrandId=AT116/21, testBrandName=Panbio (TM) Covid-19 Ag Rapid Test "
                         + "Device (Nasal), birthday=01.01.1954, pdf=[72, 101, 108, 108, 111], testResultServerHash=null," +
-                        " dcc=null)",
+                        " dcc=null, additionalInfo=Hello)",
                 quickTestArchive.toString());
     }
 

--- a/src/test/java/app/coronawarn/quicktest/entity/QuickTestTest.java
+++ b/src/test/java/app/coronawarn/quicktest/entity/QuickTestTest.java
@@ -60,6 +60,7 @@ public class QuickTestTest {
         quickTest.setHouseNumber("11");
         quickTest.setPrivacyAgreement(Boolean.FALSE);
         quickTest.setSex(Sex.DIVERSE);
+        quickTest.setAdditionalInfo("Hello");
         assertEquals(
             "QuickTest(hashedGuid=mkamhvdumyvhxeftazravmyrasozuloaghgluvbfjohpofogkylcnsybubamwnht, " +
                     "shortHashedGuid=cjfybkfn, tenantId=4711, pocId=4711-A, createdAt=2021-04-08T08:11:11, " +
@@ -70,7 +71,8 @@ public class QuickTestTest {
                     "testBrandName=Panbio (TM) Covid-19 Ag Rapid Test Device (Nasal), " +
                     "birthday=null, standardisedFamilyName=null, standardisedGivenName=null, " +
                     "diseaseAgentTargeted=null, testResultServerHash=null, " +
-                    "dccSignData=null, dccUnsigned=null, dccConsent=null, publicKey=null, dccStatus=null)",
+                    "dccSignData=null, dccUnsigned=null, dccConsent=null, publicKey=null, dccStatus=null, " +
+                    "additionalInfo=Hello)",
             quickTest.toString());
     }
 

--- a/src/test/java/app/coronawarn/quicktest/utils/PdfGeneratorTest.java
+++ b/src/test/java/app/coronawarn/quicktest/utils/PdfGeneratorTest.java
@@ -72,6 +72,7 @@ public class PdfGeneratorTest {
         when(pdfConfig.getDiverseText()).thenReturn("divers");
         when(pdfConfig.getTestResultNegativeText()).thenReturn("NEGATIV");
         when(pdfConfig.getBirthDateDescriptionText()).thenReturn("Geburtsdatum: ");
+        when(pdfConfig.getAdditionalInfoDescriptionText()).thenReturn("Zusätzliche Informationen: ");
 
         List<String> pocInformation = new ArrayList();
         pocInformation.add("PoC Unittest");
@@ -104,7 +105,7 @@ public class PdfGeneratorTest {
             assertTrue(pdfText.contains("Mehr Informationen zum Test"));
             assertTrue(pdfText.contains("Durchgeführt von: Mr. Unittest"));
             assertTrue(pdfText.contains("Test ID: AT116/21"));
-            assertTrue(pdfText.contains("Test Marke: Panbio (TM) Covid-19 Ag Rapid Test Device (Nasal)"));
+            assertTrue(pdfText.contains("Test Marke: PerGrande BioTech"));
             assertTrue(pdfText.contains("Sie sind nagativ getestet worden."));
             assertTrue(pdfText.contains("MFG"));
             assertEquals("Unittest", pdfDocument.getDocumentInformation().getAuthor());

--- a/src/test/java/app/coronawarn/quicktest/utils/PdfUtilsTest.java
+++ b/src/test/java/app/coronawarn/quicktest/utils/PdfUtilsTest.java
@@ -1,0 +1,23 @@
+package app.coronawarn.quicktest.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PdfUtilsTest {
+
+    @Test
+    void splitLongText() {
+        String s250 = "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor " +
+          "invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo" +
+          " dolores et ea rebum. Stet clita kasd gubergren, no sea tak";
+
+        List<String> strings = PdfUtils.splitStringToParagraph(s250, 50);
+        assertThat(strings.size()).isGreaterThan(1);
+        assertThat(strings).filteredOn(line -> line.trim().length() > 50).isEmpty();
+    }
+}

--- a/src/test/java/app/coronawarn/quicktest/utils/QuicktestUtils.java
+++ b/src/test/java/app/coronawarn/quicktest/utils/QuicktestUtils.java
@@ -39,7 +39,8 @@ public class QuicktestUtils {
         quicktest.setTenantId("4711");
         quicktest.setPocId("4711-A");
         quicktest.setTestBrandId("AT116/21");
-        quicktest.setTestBrandName("Panbio (TM) Covid-19 Ag Rapid Test Device (Nasal)");
+        quicktest.setTestBrandName("PerGrande BioTech Development Co., Ltd., SARS-CoV-2 Antigen Detection Kit " +
+          "(Colloidal Gold Immunochromatographic assay)");
         quicktest.setCreatedAt(LocalDateTime.of(2021, 4, 8, 8, 11, 11));
         quicktest.setUpdatedAt(LocalDateTime.of(2021, 4, 8, 8, 11, 12));
         quicktest.setFirstName("Joe");
@@ -50,6 +51,9 @@ public class QuicktestUtils {
         quicktest.setSex(Sex.DIVERSE);
         quicktest.setBirthday("1911-11-11");
         quicktest.setDiseaseAgentTargeted("COVID-19");
+        quicktest.setAdditionalInfo("Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod " +
+          "tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et " +
+          "justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea tak");
         return quicktest;
     }
 }


### PR DESCRIPTION
This PR adds an additional info field to the database and the generated PDF. 
Related Issues:
* https://github.com/corona-warn-app/cwa-quick-test-backend/issues/166
* https://github.com/corona-warn-app/cwa-quick-test-backend/issues/167

A bug concerning long antigen test names is fixed. (https://github.com/corona-warn-app/cwa-quick-test-backend/issues/159)