### PR TITLE
feat: Use arial to support unicode characters

### DIFF
--- a/src/main/java/app/coronawarn/quicktest/utils/DccPdfGenerator.java
+++ b/src/main/java/app/coronawarn/quicktest/utils/DccPdfGenerator.java
@@ -53,8 +53,8 @@ import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
-import org.apache.pdfbox.pdmodel.font.PDTrueTypeFont;
-import org.apache.pdfbox.pdmodel.font.encoding.WinAnsiEncoding;
+import org.apache.pdfbox.pdmodel.font.PDFont;
+import org.apache.pdfbox.pdmodel.font.PDType0Font;
 import org.apache.pdfbox.pdmodel.graphics.image.JPEGFactory;
 import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
 import org.apache.pdfbox.util.Matrix;
@@ -77,9 +77,9 @@ public class DccPdfGenerator {
     private final DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy-MM-dd");
     private final float leading = 14.5f;
 
-    private PDTrueTypeFont fontArial;
-    private PDTrueTypeFont fontArialBold;
-    private PDTrueTypeFont fontArialItalic;
+    private PDFont fontArial;
+    private PDFont fontArialBold;
+    private PDFont fontArialItalic;
 
     private final Color pantoneReflexBlue = Color.decode("#003399");
     private final Color pantoneYellow = Color.decode("#FFCC00");
@@ -106,15 +106,15 @@ public class DccPdfGenerator {
         // Add Arial fonts to pdfbox
         final ClassPathResource cs = new ClassPathResource("pdf/fonts/arial.ttf");
         try {
-            this.fontArial = PDTrueTypeFont.load(document,
+            this.fontArial = PDType0Font.load(document,
               Objects.requireNonNull(cs.getClassLoader())
-                .getResourceAsStream("pdf/fonts/arial.ttf"), WinAnsiEncoding.INSTANCE);
-            this.fontArialBold = PDTrueTypeFont.load(document,
+                .getResourceAsStream("pdf/fonts/arial.ttf"));
+            this.fontArialBold = PDType0Font.load(document,
               Objects.requireNonNull(cs.getClassLoader())
-                .getResourceAsStream("pdf/fonts/arialbd.ttf"), WinAnsiEncoding.INSTANCE);
-            this.fontArialItalic = PDTrueTypeFont.load(document,
+                .getResourceAsStream("pdf/fonts/arialbd.ttf"));
+            this.fontArialItalic = PDType0Font.load(document,
               Objects.requireNonNull(cs.getClassLoader())
-                .getResourceAsStream("pdf/fonts/ariali.ttf"), WinAnsiEncoding.INSTANCE);
+                .getResourceAsStream("pdf/fonts/ariali.ttf"));
         } catch (IOException e) {
             log.error("Could not load font");
         }

--- a/src/main/java/app/coronawarn/quicktest/utils/PdfGenerator.java
+++ b/src/main/java/app/coronawarn/quicktest/utils/PdfGenerator.java
@@ -44,6 +44,8 @@ import org.apache.pdfbox.pdmodel.PDDocumentInformation;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.font.PDFont;
+import org.apache.pdfbox.pdmodel.font.PDType0Font;
 import org.apache.pdfbox.pdmodel.font.PDType1Font;
 import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
 import org.springframework.core.io.ClassPathResource;
@@ -65,7 +67,7 @@ public class PdfGenerator {
     private final int offsetX = 70;
     private final float leading = 14.5f;
     private final int fontSize = 12;
-    private final PDType1Font fontType = PDType1Font.HELVETICA;
+    private PDFont fontType;
 
     /**
      * Generates a PDF file for rapid test result to print.
@@ -91,6 +93,16 @@ public class PdfGenerator {
     }
 
     private void config(PDDocument document) {
+
+        final ClassPathResource cs = new ClassPathResource("pdf/fonts/arial.ttf");
+        try {
+            this.fontType = PDType0Font.load(document,
+              Objects.requireNonNull(cs.getClassLoader())
+                .getResourceAsStream("pdf/fonts/arial.ttf"));
+        } catch (IOException e) {
+            log.error("Could not load font");
+        }
+
         PDDocumentInformation pdd = document.getDocumentInformation();
         pdd.setAuthor(pdfConfig.getAuthorPdfPropertiesText());
         pdd.setTitle(pdfConfig.getQuickTestHeadlineText());

--- a/src/test/java/app/coronawarn/quicktest/utils/PdfGeneratorTest.java
+++ b/src/test/java/app/coronawarn/quicktest/utils/PdfGeneratorTest.java
@@ -91,7 +91,8 @@ public class PdfGeneratorTest {
             assertTrue(pdfText.contains("Unittest Way 15"));
             assertTrue(pdfText.contains("10101 Unittest City"));
             assertTrue(pdfText.contains("Call: 0123-7890-0"));
-            assertTrue(pdfText.contains("Joe Miller"));
+            // Test for unicode character ę
+            assertTrue(pdfText.contains("Joę Miller"));
             assertTrue(pdfText.contains("Boe 11"));
             assertTrue(pdfText.contains("12345 oyvkpigcga"));
             assertTrue(pdfText.contains("Telefon: 00491777777777777"));

--- a/src/test/java/app/coronawarn/quicktest/utils/QuicktestUtils.java
+++ b/src/test/java/app/coronawarn/quicktest/utils/QuicktestUtils.java
@@ -43,7 +43,7 @@ public class QuicktestUtils {
           "(Colloidal Gold Immunochromatographic assay)");
         quicktest.setCreatedAt(LocalDateTime.of(2021, 4, 8, 8, 11, 11));
         quicktest.setUpdatedAt(LocalDateTime.of(2021, 4, 8, 8, 11, 12));
-        quicktest.setFirstName("Joe");
+        quicktest.setFirstName("Joę");
         quicktest.setLastName("Miller");
         quicktest.setStreet("Boe");
         quicktest.setHouseNumber("11");


### PR DESCRIPTION
Use arial to support unicode chars in personal data