### PR TITLE
fix: use group name from token as tescenter in dcc pdf

### DIFF
--- a/src/main/java/app/coronawarn/quicktest/domain/QuickTest.java
+++ b/src/main/java/app/coronawarn/quicktest/domain/QuickTest.java
@@ -190,6 +190,10 @@ public class QuickTest {
     @Convert(converter = DbEncryptionStringConverter.class)
     private String additionalInfo;
 
+    @Column(name = "group_name")
+    @Convert(converter = DbEncryptionStringConverter.class)
+    private String groupName;
+
     @PrePersist
     private void onCreate() {
         LocalDateTime now = Utilities.getCurrentLocalDateTimeUtc();

--- a/src/main/java/app/coronawarn/quicktest/domain/QuickTestArchive.java
+++ b/src/main/java/app/coronawarn/quicktest/domain/QuickTestArchive.java
@@ -150,4 +150,8 @@ public class QuickTestArchive {
     @Column(name = "additional_info")
     @Convert(converter = DbEncryptionStringConverter.class)
     private String additionalInfo;
+
+    @Column(name = "group_name")
+    @Convert(converter = DbEncryptionStringConverter.class)
+    private String groupName;
 }

--- a/src/main/java/app/coronawarn/quicktest/service/QuickTestService.java
+++ b/src/main/java/app/coronawarn/quicktest/service/QuickTestService.java
@@ -34,6 +34,7 @@ import app.coronawarn.quicktest.repository.QuickTestLogRepository;
 import app.coronawarn.quicktest.repository.QuickTestRepository;
 import app.coronawarn.quicktest.repository.QuicktestView;
 import app.coronawarn.quicktest.utils.PdfGenerator;
+import app.coronawarn.quicktest.utils.Utilities;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -59,6 +60,7 @@ public class QuickTestService {
     private final QuickTestArchiveRepository quickTestArchiveRepository;
     private final QuickTestLogRepository quickTestLogRepository;
     private final PdfGenerator pdf;
+    private final Utilities utilities;
 
     /**
      * Checks if an other quick test with given short hash already exists.
@@ -93,6 +95,7 @@ public class QuickTestService {
         newQuickTest.setTenantId(ids.get(quickTestConfig.getTenantIdKey()));
         newQuickTest.setPocId(ids.get(quickTestConfig.getTenantPointOfCareIdKey()));
         newQuickTest.setHashedGuid(hashedGuid);
+        newQuickTest.setGroupName(utilities.getSubGroupFromToken().orElse(""));
 
         log.debug("Persisting QuickTest in database");
         try {
@@ -297,6 +300,7 @@ public class QuickTestService {
         quickTestArchive.setPdf(pdf);
         quickTestArchive.setTestResultServerHash(quickTest.getTestResultServerHash());
         quickTestArchive.setAdditionalInfo(quickTest.getAdditionalInfo());
+        quickTestArchive.setGroupName(quickTest.getGroupName());
         return quickTestArchive;
     }
 

--- a/src/main/java/app/coronawarn/quicktest/utils/DccPdfGenerator.java
+++ b/src/main/java/app/coronawarn/quicktest/utils/DccPdfGenerator.java
@@ -509,7 +509,7 @@ public class DccPdfGenerator {
             quickTest.getUpdatedAt().format(formatter)),
           List.of(pdfConfig.getCertTestResultDe(), pdfConfig.getCertTestResultEn(),
             getTestResultText(quickTest.getTestResult())),
-          List.of(pdfConfig.getCertTestingCentreDe(), pdfConfig.getCertTestingCentreEn(), quickTest.getPocId()),
+          List.of(pdfConfig.getCertTestingCentreDe(), pdfConfig.getCertTestingCentreEn(), quickTest.getGroupName()),
           List.of(pdfConfig.getCertStateOfTestDe(), pdfConfig.getCertStateOfTestEn(), pdfConfig.getCertIssuerState()),
           List.of(pdfConfig.getCertIssuerDe(), pdfConfig.getCertIssuerEn(), dccDecodeResult.getIssuer())
         );

--- a/src/main/resources/db/changelog.yml
+++ b/src/main/resources/db/changelog.yml
@@ -41,3 +41,6 @@ databaseChangeLog:
   - include:
       file: changelog/V014_add_additional_info_column.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/V015_add_groupname_column.yml
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/V015_add_groupname_column.yml
+++ b/src/main/resources/db/changelog/V015_add_groupname_column.yml
@@ -1,0 +1,17 @@
+databaseChangeLog:
+  - changeSet:
+      id: add-groupname-columns
+      author: bergmann-dierk
+      changes:
+        - addColumn:
+            tableName: quick_test
+            columns:
+              - column:
+                  name: group_name
+                  type: varchar(100)
+        - addColumn:
+            tableName: quick_test_archive
+            columns:
+              - column:
+                  name: group_name
+                  type: varchar(100)

--- a/src/test/java/app/coronawarn/quicktest/entity/QuickTestArchiveTest.java
+++ b/src/test/java/app/coronawarn/quicktest/entity/QuickTestArchiveTest.java
@@ -61,6 +61,7 @@ public class QuickTestArchiveTest {
         quickTestArchive.setSex(Sex.DIVERSE);
         quickTestArchive.setPdf("Hello".getBytes());
         quickTestArchive.setAdditionalInfo("Hello");
+        quickTestArchive.setGroupName("Barmen");
         assertEquals("QuickTestArchive(hashedGuid=mkamhvdumyvhxeftazravmyrasozuloaghgluvbfjohpofogkylcnsybubamwnht, "
                         + "shortHashedGuid=cjfybkfn, tenantId=4711, pocId=4711-A, createdAt=2021-04-08T08:11:11, "
                         + "updatedAt=2021-04-08T08:11:12, version=null, confirmationCwa=true, testResult=5, "
@@ -68,7 +69,7 @@ public class QuickTestArchiveTest {
                         + "phoneNumber=00491777777777777, sex=DIVERSE, street=Boe, houseNumber=11, zipCode=12345, "
                         + "city=oyvkpigcga, testBrandId=AT116/21, testBrandName=Panbio (TM) Covid-19 Ag Rapid Test "
                         + "Device (Nasal), birthday=01.01.1954, pdf=[72, 101, 108, 108, 111], testResultServerHash=null," +
-                        " dcc=null, additionalInfo=Hello)",
+                        " dcc=null, additionalInfo=Hello, groupName=Barmen)",
                 quickTestArchive.toString());
     }
 

--- a/src/test/java/app/coronawarn/quicktest/entity/QuickTestTest.java
+++ b/src/test/java/app/coronawarn/quicktest/entity/QuickTestTest.java
@@ -61,6 +61,7 @@ public class QuickTestTest {
         quickTest.setPrivacyAgreement(Boolean.FALSE);
         quickTest.setSex(Sex.DIVERSE);
         quickTest.setAdditionalInfo("Hello");
+        quickTest.setGroupName("Barmen");
         assertEquals(
             "QuickTest(hashedGuid=mkamhvdumyvhxeftazravmyrasozuloaghgluvbfjohpofogkylcnsybubamwnht, " +
                     "shortHashedGuid=cjfybkfn, tenantId=4711, pocId=4711-A, createdAt=2021-04-08T08:11:11, " +
@@ -72,7 +73,7 @@ public class QuickTestTest {
                     "birthday=null, standardisedFamilyName=null, standardisedGivenName=null, " +
                     "diseaseAgentTargeted=null, testResultServerHash=null, " +
                     "dccSignData=null, dccUnsigned=null, dccConsent=null, publicKey=null, dccStatus=null, " +
-                    "additionalInfo=Hello)",
+                    "additionalInfo=Hello, groupName=Barmen)",
             quickTest.toString());
     }
 

--- a/src/test/java/app/coronawarn/quicktest/utils/QuicktestUtils.java
+++ b/src/test/java/app/coronawarn/quicktest/utils/QuicktestUtils.java
@@ -54,6 +54,7 @@ public class QuicktestUtils {
         quicktest.setAdditionalInfo("Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod " +
           "tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et " +
           "justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea tak");
+        quicktest.setGroupName("Mein Testcenter mit fünfzig Zeichen Testzertifikat");
         return quicktest;
     }
 }


### PR DESCRIPTION
Instead of pocId the name of the subgroup of the PoC user should be used in the DCC PDF.