### PR TITLE
feat: use Keycloak Group ID as POC ID

### DIFF
--- a/src/main/java/app/coronawarn/quicktest/controller/GroupManagementController.java
+++ b/src/main/java/app/coronawarn/quicktest/controller/GroupManagementController.java
@@ -163,7 +163,7 @@ public class GroupManagementController {
         GroupRepresentation userRootGroup = utils.checkUserRootGroup();
 
         try {
-            keycloakService.createGroup(body.getName(), body.getPocDetails(), body.getPocId(), userRootGroup.getId());
+            keycloakService.createGroup(body.getName(), body.getPocDetails(), userRootGroup.getId());
         } catch (KeycloakService.KeycloakServiceException e) {
             if (e.getReason() == KeycloakService.KeycloakServiceException.Reason.NOT_FOUND) {
                 throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Group not found");
@@ -212,10 +212,12 @@ public class GroupManagementController {
         utils.checkGroupIsInSubgroups(userRootGroup, id);
 
         try {
-            keycloakService.updateGroup(id, body.getName(), body.getPocDetails(), body.getPocId());
+            keycloakService.updateGroup(id, body.getName(), body.getPocDetails());
         } catch (KeycloakService.KeycloakServiceException e) {
             if (e.getReason() == KeycloakService.KeycloakServiceException.Reason.NOT_FOUND) {
                 throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Group not found");
+            } else if (e.getReason() == KeycloakService.KeycloakServiceException.Reason.ALREADY_EXISTS) {
+                throw new ResponseStatusException(HttpStatus.CONFLICT, "Group with this name already exists");
             } else {
                 throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to update group");
             }

--- a/src/main/java/app/coronawarn/quicktest/service/KeycloakService.java
+++ b/src/main/java/app/coronawarn/quicktest/service/KeycloakService.java
@@ -442,7 +442,7 @@ public class KeycloakService {
 
         group.setName(name);
         // do not update POC ID
-        group.setAttributes(getGroupAttributes(pocDetails, group.getId()));
+        group.setAttributes(getGroupAttributes(pocDetails, getFromAttributes(group.getAttributes(), POC_ID_ATTRIBUTE)));
 
         try {
             groupResource.update(group);

--- a/src/main/java/app/coronawarn/quicktest/service/KeycloakService.java
+++ b/src/main/java/app/coronawarn/quicktest/service/KeycloakService.java
@@ -429,9 +429,8 @@ public class KeycloakService {
      * @param id         ID of the group to be updated.
      * @param name       New name
      * @param pocDetails new POC Details
-     * @param pocId      new POC ID
      */
-    public void updateGroup(String id, String name, String pocDetails, String pocId) throws KeycloakServiceException {
+    public void updateGroup(String id, String name, String pocDetails) throws KeycloakServiceException {
         log.info("Updating group with id {}", id);
         GroupResource groupResource = realm().groups().group(id);
         GroupRepresentation group;
@@ -442,7 +441,8 @@ public class KeycloakService {
         }
 
         group.setName(name);
-        group.setAttributes(getGroupAttributes(pocDetails, pocId));
+        // do not update POC ID
+        group.setAttributes(getGroupAttributes(pocDetails, group.getId()));
 
         try {
             groupResource.update(group);
@@ -451,8 +451,13 @@ public class KeycloakService {
             log.error("Failed to update group: BAD REQUEST {}", e.getResponse().readEntity(String.class));
             throw new KeycloakServiceException(KeycloakServiceException.Reason.BAD_REQUEST);
         } catch (WebApplicationException e) {
-            log.error("Failed to update group: SERVER ERROR {}", e.getResponse().readEntity(String.class));
-            throw new KeycloakServiceException(KeycloakServiceException.Reason.SERVER_ERROR);
+            if (e.getResponse().getStatus() == HttpStatus.CONFLICT.value()) {
+                log.error("Failed to update group: CONFLICT {}", e.getResponse().readEntity(String.class));
+                throw new KeycloakServiceException(KeycloakServiceException.Reason.ALREADY_EXISTS);
+            } else {
+                log.error("Failed to update group: SERVER ERROR {}", e.getResponse().readEntity(String.class));
+                throw new KeycloakServiceException(KeycloakServiceException.Reason.SERVER_ERROR);
+            }
         }
     }
 
@@ -461,24 +466,27 @@ public class KeycloakService {
      *
      * @param name       Name of the new group
      * @param pocDetails POC Details of the new group
-     * @param pocId      POC ID of the new group
      * @param parent     ID of the parent group
      */
-    public void createGroup(String name, String pocDetails, String pocId, String parent)
+    public void createGroup(String name, String pocDetails, String parent)
         throws KeycloakServiceException {
         log.info("Creating new group");
         GroupRepresentation newGroup = new GroupRepresentation();
         newGroup.setName(name);
-        newGroup.setAttributes(getGroupAttributes(pocDetails, pocId));
 
         try {
             Response response = realm().groups().group(parent).subGroup(newGroup);
-
             if (response.getStatus() == HttpStatus.CONFLICT.value()) {
                 log.error("Failed to create group: CONFLICT");
                 throw new KeycloakServiceException(KeycloakServiceException.Reason.ALREADY_EXISTS);
             }
             log.info("created group");
+
+            // setting group properties with Grup Details and POC ID
+            newGroup = response.readEntity(GroupRepresentation.class);
+            newGroup.setAttributes(getGroupAttributes(pocDetails, newGroup.getId()));
+            realm().groups().group(newGroup.getId()).update(newGroup);
+
         } catch (BadRequestException e) {
             log.error("Failed to create group: BAD REQUEST {}", e.getResponse().readEntity(String.class));
             throw new KeycloakServiceException(KeycloakServiceException.Reason.BAD_REQUEST);

--- a/src/test/java/app/coronawarn/quicktest/controller/GroupManagementControllerTest.java
+++ b/src/test/java/app/coronawarn/quicktest/controller/GroupManagementControllerTest.java
@@ -312,7 +312,7 @@ class GroupManagementControllerTest extends ServletKeycloakAuthUnitTestingSuppor
                 .content(objectMapper.writeValueAsString(groupDetails)))
             .andExpect(status().isCreated());
 
-        verify(keycloakServiceMock).createGroup(groupDetails.getName(), groupDetails.getPocDetails(), groupDetails.getPocId(), rootGroupId);
+        verify(keycloakServiceMock).createGroup(groupDetails.getName(), groupDetails.getPocDetails(), rootGroupId);
     }
 
     @Test
@@ -327,7 +327,7 @@ class GroupManagementControllerTest extends ServletKeycloakAuthUnitTestingSuppor
         groupDetails.setPocId("pocId");
 
         doThrow(new KeycloakService.KeycloakServiceException(KeycloakService.KeycloakServiceException.Reason.NOT_FOUND))
-            .when(keycloakServiceMock).createGroup(any(), any(), any(), any());
+            .when(keycloakServiceMock).createGroup(any(), any(), any());
 
         mockMvc().perform(MockMvcRequestBuilders
                 .post("/api/usermanagement/groups")
@@ -335,7 +335,7 @@ class GroupManagementControllerTest extends ServletKeycloakAuthUnitTestingSuppor
                 .content(objectMapper.writeValueAsString(groupDetails)))
             .andExpect(status().isNotFound());
 
-        verify(keycloakServiceMock).createGroup(groupDetails.getName(), groupDetails.getPocDetails(), groupDetails.getPocId(), rootGroupId);
+        verify(keycloakServiceMock).createGroup(groupDetails.getName(), groupDetails.getPocDetails(), rootGroupId);
     }
 
     @Test
@@ -350,7 +350,7 @@ class GroupManagementControllerTest extends ServletKeycloakAuthUnitTestingSuppor
         groupDetails.setPocId("pocId");
 
         doThrow(new KeycloakService.KeycloakServiceException(KeycloakService.KeycloakServiceException.Reason.ALREADY_EXISTS))
-            .when(keycloakServiceMock).createGroup(any(), any(), any(), any());
+            .when(keycloakServiceMock).createGroup(any(), any(), any());
 
         mockMvc().perform(MockMvcRequestBuilders
                 .post("/api/usermanagement/groups")
@@ -358,7 +358,7 @@ class GroupManagementControllerTest extends ServletKeycloakAuthUnitTestingSuppor
                 .content(objectMapper.writeValueAsString(groupDetails)))
             .andExpect(status().isConflict());
 
-        verify(keycloakServiceMock).createGroup(groupDetails.getName(), groupDetails.getPocDetails(), groupDetails.getPocId(), rootGroupId);
+        verify(keycloakServiceMock).createGroup(groupDetails.getName(), groupDetails.getPocDetails(), rootGroupId);
     }
 
     @Test
@@ -373,7 +373,7 @@ class GroupManagementControllerTest extends ServletKeycloakAuthUnitTestingSuppor
         groupDetails.setPocId("pocId");
 
         doThrow(new KeycloakService.KeycloakServiceException(KeycloakService.KeycloakServiceException.Reason.SERVER_ERROR))
-            .when(keycloakServiceMock).createGroup(any(), any(), any(), any());
+            .when(keycloakServiceMock).createGroup(any(), any(), any());
 
         mockMvc().perform(MockMvcRequestBuilders
                 .post("/api/usermanagement/groups")
@@ -381,7 +381,7 @@ class GroupManagementControllerTest extends ServletKeycloakAuthUnitTestingSuppor
                 .content(objectMapper.writeValueAsString(groupDetails)))
             .andExpect(status().isInternalServerError());
 
-        verify(keycloakServiceMock).createGroup(groupDetails.getName(), groupDetails.getPocDetails(), groupDetails.getPocId(), rootGroupId);
+        verify(keycloakServiceMock).createGroup(groupDetails.getName(), groupDetails.getPocDetails(), rootGroupId);
     }
 
     @Test
@@ -479,7 +479,7 @@ class GroupManagementControllerTest extends ServletKeycloakAuthUnitTestingSuppor
                 .content(objectMapper.writeValueAsString(groupDetails)))
             .andExpect(status().isNoContent());
 
-        verify(keycloakServiceMock).updateGroup(subGroupId, groupDetails.getName(), groupDetails.getPocDetails(), groupDetails.getPocId());
+        verify(keycloakServiceMock).updateGroup(subGroupId, groupDetails.getName(), groupDetails.getPocDetails());
     }
 
     @Test
@@ -494,7 +494,7 @@ class GroupManagementControllerTest extends ServletKeycloakAuthUnitTestingSuppor
         groupDetails.setPocId("pocId");
 
         doThrow(new KeycloakService.KeycloakServiceException(KeycloakService.KeycloakServiceException.Reason.NOT_FOUND))
-            .when(keycloakServiceMock).updateGroup(any(), any(), any(), any());
+            .when(keycloakServiceMock).updateGroup(any(), any(), any());
 
         mockMvc().perform(MockMvcRequestBuilders
                 .put("/api/usermanagement/groups/" + subGroupId)
@@ -502,7 +502,7 @@ class GroupManagementControllerTest extends ServletKeycloakAuthUnitTestingSuppor
                 .content(objectMapper.writeValueAsString(groupDetails)))
             .andExpect(status().isNotFound());
 
-        verify(keycloakServiceMock).updateGroup(subGroupId, groupDetails.getName(), groupDetails.getPocDetails(), groupDetails.getPocId());
+        verify(keycloakServiceMock).updateGroup(subGroupId, groupDetails.getName(), groupDetails.getPocDetails());
     }
 
     @Test
@@ -517,7 +517,7 @@ class GroupManagementControllerTest extends ServletKeycloakAuthUnitTestingSuppor
         groupDetails.setPocId("pocId");
 
         doThrow(new KeycloakService.KeycloakServiceException(KeycloakService.KeycloakServiceException.Reason.SERVER_ERROR))
-            .when(keycloakServiceMock).updateGroup(any(), any(), any(), any());
+            .when(keycloakServiceMock).updateGroup(any(), any(), any());
 
         mockMvc().perform(MockMvcRequestBuilders
                 .put("/api/usermanagement/groups/" + subGroupId)
@@ -525,7 +525,7 @@ class GroupManagementControllerTest extends ServletKeycloakAuthUnitTestingSuppor
                 .content(objectMapper.writeValueAsString(groupDetails)))
             .andExpect(status().isInternalServerError());
 
-        verify(keycloakServiceMock).updateGroup(subGroupId, groupDetails.getName(), groupDetails.getPocDetails(), groupDetails.getPocId());
+        verify(keycloakServiceMock).updateGroup(subGroupId, groupDetails.getName(), groupDetails.getPocDetails());
     }
 
     @Test

--- a/src/test/java/app/coronawarn/quicktest/service/KeycloakServiceTest.java
+++ b/src/test/java/app/coronawarn/quicktest/service/KeycloakServiceTest.java
@@ -722,7 +722,7 @@ public class KeycloakServiceTest {
         Assertions.assertEquals("newName", captor.getValue().getName());
         Assertions.assertEquals(2, captor.getValue().getAttributes().size());
         Assertions.assertEquals(1, captor.getValue().getAttributes().get("poc_id").size());
-        Assertions.assertEquals(groupid, captor.getValue().getAttributes().get("poc_id").get(0));
+        Assertions.assertEquals(groupPocId, captor.getValue().getAttributes().get("poc_id").get(0));
         Assertions.assertEquals(1, captor.getValue().getAttributes().get("poc_details").size());
         Assertions.assertEquals("newPocDetails", captor.getValue().getAttributes().get("poc_details").get(0));
 


### PR DESCRIPTION
This PR contains two features:
* Use Keycloak Group ID as POC ID (When Creating a Group)
* Return 409 on Group Update when Name already exists