### PR TITLE
bsnr (Betriebsstaettennummer) for new PoCs

### DIFF
--- a/src/main/java/app/coronawarn/quicktest/config/QuickTestConfig.java
+++ b/src/main/java/app/coronawarn/quicktest/config/QuickTestConfig.java
@@ -35,6 +35,7 @@ public class QuickTestConfig {
     private String pointOfCareIdName;
     private String tenantIdKey;
     private String groupKey;
+    private String bsnrKey;
     private String tenantPointOfCareIdKey;
     private String pointOfCareInformationName;
     private String pointOfCareInformationDelimiter;

--- a/src/main/java/app/coronawarn/quicktest/model/keycloak/KeycloakGroupDetails.java
+++ b/src/main/java/app/coronawarn/quicktest/model/keycloak/KeycloakGroupDetails.java
@@ -55,4 +55,7 @@ public class KeycloakGroupDetails {
 
     private Boolean appointmentRequired;
 
+    // Optional Betriebsstaettennummer of a poc
+    @Size(min = 9, max = 9)
+    private String bsnr;
 }

--- a/src/main/java/app/coronawarn/quicktest/service/KeycloakService.java
+++ b/src/main/java/app/coronawarn/quicktest/service/KeycloakService.java
@@ -71,6 +71,7 @@ public class KeycloakService {
 
     private static final String POC_ID_ATTRIBUTE = "poc_id";
     private static final String POC_DETAILS_ATTRIBUTE = "poc_details";
+    private static final String BSNR_ATTRIBUTE = "bsnr";
 
     /**
      * Creates a new Keycloak User in the Main Realm and sets roles and the root group.
@@ -237,6 +238,7 @@ public class KeycloakService {
         groupDetails.setName(group.getName());
         groupDetails.setPocDetails(getFromAttributes(group.getAttributes(), POC_DETAILS_ATTRIBUTE));
         groupDetails.setPocId(getFromAttributes(group.getAttributes(), POC_ID_ATTRIBUTE));
+        groupDetails.setBsnr(getFromAttributes(group.getAttributes(), BSNR_ATTRIBUTE));
         MapEntrySingleResponse mapEntry = mapEntryService.getMapEntry(groupId);
         if (mapEntry != null) {
             log.info(mapEntry.toString());
@@ -497,7 +499,7 @@ public class KeycloakService {
         group.setName(details.getName());
         // do not update POC ID
         group.setAttributes(getGroupAttributes(details.getPocDetails(),
-                getFromAttributes(group.getAttributes(), POC_ID_ATTRIBUTE)));
+                getFromAttributes(group.getAttributes(), POC_ID_ATTRIBUTE), details.getBsnr()));
 
         try {
             groupResource.update(group);
@@ -541,7 +543,7 @@ public class KeycloakService {
             log.info("created group");
             // setting group properties with Group Details and POC ID
             newGroup = response.readEntity(GroupRepresentation.class);
-            newGroup.setAttributes(getGroupAttributes(details.getPocDetails(), newGroup.getId()));
+            newGroup.setAttributes(getGroupAttributes(details.getPocDetails(), newGroup.getId(), details.getBsnr()));
             realm().groups().group(newGroup.getId()).update(newGroup);
             if (details.getSearchPortalConsent()) {
                 details.setId(newGroup.getId());
@@ -634,7 +636,7 @@ public class KeycloakService {
         }
     }
 
-    private Map<String, List<String>> getGroupAttributes(String pocDetails, String pocId) {
+    private Map<String, List<String>> getGroupAttributes(String pocDetails, String pocId, String bsnr) {
         Map<String, List<String>> attributes = new HashMap<>();
         if (pocDetails != null) {
             attributes.put(POC_DETAILS_ATTRIBUTE, List.of(pocDetails));
@@ -642,6 +644,10 @@ public class KeycloakService {
 
         if (pocId != null) {
             attributes.put(POC_ID_ATTRIBUTE, List.of(pocId));
+        }
+
+        if (bsnr != null) {
+            attributes.put(BSNR_ATTRIBUTE, List.of(bsnr));
         }
 
         return attributes;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -78,6 +78,7 @@ quicktest:
   pointOfCareIdName: poc_id
   tenantIdKey: tenantId
   groupKey: groups
+  bsnrKey: bsnr
   tenantPointOfCareIdKey: pocId
   pointOfCareInformationName: poc_details
   pointOfCareInformationDelimiter: \,


### PR DESCRIPTION
Bsnr can be added to a new or existing group in keycloak. To include the bsnr in the token a new mapper in keycloak has to be configured.