### PR TITLE
feat: Use projection to find quicktestArchive

### DIFF
--- a/src/main/java/app/coronawarn/quicktest/controller/QuickTestArchiveController.java
+++ b/src/main/java/app/coronawarn/quicktest/controller/QuickTestArchiveController.java
@@ -23,9 +23,9 @@ package app.coronawarn.quicktest.controller;
 import static app.coronawarn.quicktest.config.SecurityConfig.ROLE_COUNTER;
 import static app.coronawarn.quicktest.config.SecurityConfig.ROLE_LAB;
 
-import app.coronawarn.quicktest.domain.QuickTestArchive;
 import app.coronawarn.quicktest.model.quicktest.QuickTestArchiveResponse;
 import app.coronawarn.quicktest.model.quicktest.QuickTestArchiveResponseList;
+import app.coronawarn.quicktest.repository.QuickTestArchiveView;
 import app.coronawarn.quicktest.service.QuickTestArchiveService;
 import app.coronawarn.quicktest.utils.Utilities;
 import io.swagger.v3.oas.annotations.Operation;
@@ -124,7 +124,7 @@ public class QuickTestArchiveController {
         try {
             LocalDateTime utcDateFrom = LocalDateTime.ofInstant(zonedDateFrom.toInstant(), ZoneOffset.UTC);
             LocalDateTime utcDateTo = LocalDateTime.ofInstant(zonedDateTo.toInstant(), ZoneOffset.UTC);
-            List<QuickTestArchive> archives = quickTestArchiveService.findByTestResultAndUpdatedAtBetween(
+            List<QuickTestArchiveView> archives = quickTestArchiveService.findByTestResultAndUpdatedAtBetween(
                 utilities.getIdsFromToken(),
                 testResult,
                 utcDateFrom,

--- a/src/main/java/app/coronawarn/quicktest/model/quicktest/QuickTestArchiveResponse.java
+++ b/src/main/java/app/coronawarn/quicktest/model/quicktest/QuickTestArchiveResponse.java
@@ -20,7 +20,6 @@
 
 package app.coronawarn.quicktest.model.quicktest;
 
-import app.coronawarn.quicktest.model.Sex;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
@@ -31,27 +30,5 @@ import lombok.Data;
 public class QuickTestArchiveResponse {
 
     private String hashedGuid;
-
-    private String lastName;
-
-    private String firstName;
-
-    private String email;
-
-    private String phoneNumber;
-
-    private Sex sex;
-
-    private String street;
-
-    private String houseNumber;
-
-    private String zipCode;
-
-    private String city;
-
-    private String birthday;
-
-    private String testResult;
 
 }

--- a/src/main/java/app/coronawarn/quicktest/repository/QuickTestArchiveRepository.java
+++ b/src/main/java/app/coronawarn/quicktest/repository/QuickTestArchiveRepository.java
@@ -30,14 +30,14 @@ public interface QuickTestArchiveRepository extends JpaRepository<QuickTestArchi
 
     Optional<QuickTestArchive> findByHashedGuid(String hashedGuid);
 
-    List<QuickTestArchive> findAllByTenantIdAndPocIdAndUpdatedAtBetween(
+    List<QuickTestArchiveView> findAllByTenantIdAndPocIdAndUpdatedAtBetween(
         String tenantId,
         String pocId,
         LocalDateTime dateFrom,
         LocalDateTime dateTo
     );
 
-    List<QuickTestArchive> findAllByTenantIdAndPocIdAndTestResultAndUpdatedAtBetween(
+    List<QuickTestArchiveView> findAllByTenantIdAndPocIdAndTestResultAndUpdatedAtBetween(
             String tenantId,
             String pocId,
             Short testResult,

--- a/src/main/java/app/coronawarn/quicktest/repository/QuickTestArchiveView.java
+++ b/src/main/java/app/coronawarn/quicktest/repository/QuickTestArchiveView.java
@@ -1,0 +1,5 @@
+package app.coronawarn.quicktest.repository;
+
+public interface QuickTestArchiveView {
+    String getHashedGuid();
+}

--- a/src/main/java/app/coronawarn/quicktest/service/QuickTestArchiveService.java
+++ b/src/main/java/app/coronawarn/quicktest/service/QuickTestArchiveService.java
@@ -23,6 +23,7 @@ package app.coronawarn.quicktest.service;
 import app.coronawarn.quicktest.config.QuickTestConfig;
 import app.coronawarn.quicktest.domain.QuickTestArchive;
 import app.coronawarn.quicktest.repository.QuickTestArchiveRepository;
+import app.coronawarn.quicktest.repository.QuickTestArchiveView;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -69,9 +70,9 @@ public class QuickTestArchiveService {
      * @return quickTestArchives List of all found quickTestArchives
      */
     @Transactional(readOnly = true)
-    public List<QuickTestArchive> findByTestResultAndUpdatedAtBetween(
+    public List<QuickTestArchiveView> findByTestResultAndUpdatedAtBetween(
         Map<String, String> ids, Short testResult, LocalDateTime dateFrom, LocalDateTime dateTo) {
-        List<QuickTestArchive> archives;
+        List<QuickTestArchiveView> archives;
         if (testResult == null) {
             archives = quickTestArchiveRepository.findAllByTenantIdAndPocIdAndUpdatedAtBetween(
                 ids.get(quickTestConfig.getTenantIdKey()),

--- a/src/test/java/app/coronawarn/quicktest/controller/QuickTestArchiveControllerTest.java
+++ b/src/test/java/app/coronawarn/quicktest/controller/QuickTestArchiveControllerTest.java
@@ -34,16 +34,13 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import app.coronawarn.quicktest.config.QuicktestKeycloakSpringBootConfigResolver;
-import app.coronawarn.quicktest.domain.QuickTestArchive;
-import app.coronawarn.quicktest.model.quicktest.QuickTestArchiveResponseList;
 import app.coronawarn.quicktest.model.quicktest.QuickTestArchiveResponse;
-import app.coronawarn.quicktest.model.Sex;
+import app.coronawarn.quicktest.model.quicktest.QuickTestArchiveResponseList;
+import app.coronawarn.quicktest.repository.QuickTestArchiveView;
 import app.coronawarn.quicktest.service.QuickTestArchiveService;
 import app.coronawarn.quicktest.utils.Utilities;
 import com.c4_soft.springaddons.security.oauth2.test.mockmvc.keycloak.ServletKeycloakAuthUnitTestingSupport;
 import com.google.gson.Gson;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
@@ -131,28 +128,8 @@ class QuickTestArchiveControllerTest extends ServletKeycloakAuthUnitTestingSuppo
     @Test
     void findArchivesByTestResultAndUpdatedAtBetween() throws Exception {
 
-        QuickTestArchive quickTestArchive = new QuickTestArchive();
-        quickTestArchive.setHashedGuid("6fa4dcecf716d8dd96c9e927dda5484f1a8a9da03155aa760e0c38f9bed645c4");
-        quickTestArchive.setShortHashedGuid("6fa4dcec");
-        quickTestArchive.setTenantId("tenant");
-        quickTestArchive.setCreatedAt(LocalDateTime.now());
-        quickTestArchive.setUpdatedAt(LocalDateTime.now());
-        quickTestArchive.setConfirmationCwa(true);
-        quickTestArchive.setTestResult((short) 6);
-        quickTestArchive.setPrivacyAgreement(true);
-        quickTestArchive.setLastName("1");
-        quickTestArchive.setFirstName("1");
-        quickTestArchive.setEmail("v@e.o");
-        quickTestArchive.setPhoneNumber("+490000");
-        quickTestArchive.setSex(Sex.DIVERSE);
-        quickTestArchive.setStreet("f");
-        quickTestArchive.setHouseNumber("a");
-        quickTestArchive.setZipCode("11111");
-        quickTestArchive.setCity("f");
-        quickTestArchive.setTestBrandId("testbrand");
-        quickTestArchive.setTestBrandName("brandname");
-        quickTestArchive.setBirthday(LocalDate.now().toString());
-        quickTestArchive.setPdf("test output".getBytes());
+        QuickTestArchiveView quickTestArchive =
+          () -> "6fa4dcecf716d8dd96c9e927dda5484f1a8a9da03155aa760e0c38f9bed645c4";
         when(quickTestArchiveService.findByTestResultAndUpdatedAtBetween(any(), anyShort(), any(), any())).thenReturn(
             Collections.singletonList(quickTestArchive));
 
@@ -296,18 +273,7 @@ class QuickTestArchiveControllerTest extends ServletKeycloakAuthUnitTestingSuppo
 
     }
 
-    private void checkResponse(QuickTestArchiveResponse response, QuickTestArchive quickTestArchive) {
+    private void checkResponse(QuickTestArchiveResponse response, QuickTestArchiveView quickTestArchive) {
         assertEquals(quickTestArchive.getHashedGuid(), response.getHashedGuid());
-        assertEquals(quickTestArchive.getLastName(), response.getLastName());
-        assertEquals(quickTestArchive.getFirstName(), response.getFirstName());
-        assertEquals(quickTestArchive.getEmail(), response.getEmail());
-        assertEquals(quickTestArchive.getPhoneNumber(), response.getPhoneNumber());
-        assertEquals(quickTestArchive.getSex(), response.getSex());
-        assertEquals(quickTestArchive.getStreet(), response.getStreet());
-        assertEquals(quickTestArchive.getHouseNumber(), response.getHouseNumber());
-        assertEquals(quickTestArchive.getZipCode(), response.getZipCode());
-        assertEquals(quickTestArchive.getCity(), response.getCity());
-        assertEquals(quickTestArchive.getBirthday(), response.getBirthday());
-        assertEquals(quickTestArchive.getTestResult().toString(), response.getTestResult());
     }
 }

--- a/src/test/java/app/coronawarn/quicktest/service/QuickTestArchiveServiceTest.java
+++ b/src/test/java/app/coronawarn/quicktest/service/QuickTestArchiveServiceTest.java
@@ -32,6 +32,7 @@ import app.coronawarn.quicktest.config.QuickTestConfig;
 import app.coronawarn.quicktest.domain.QuickTestArchive;
 import app.coronawarn.quicktest.model.Sex;
 import app.coronawarn.quicktest.repository.QuickTestArchiveRepository;
+import app.coronawarn.quicktest.repository.QuickTestArchiveView;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collections;
@@ -104,11 +105,12 @@ public class QuickTestArchiveServiceTest {
 
     @Test
     void findByTestResultAndUpdatedAtBetweenTest() {
+        String hashedGuid = quickTestArchive.getHashedGuid();
         when(quickTestArchiveRepository.findAllByTenantIdAndPocIdAndUpdatedAtBetween(any(), any(), any(), any()))
-            .thenReturn(Collections.singletonList(quickTestArchive));
+            .thenReturn(Collections.singletonList(() -> hashedGuid));
         when(quickTestArchiveRepository.findAllByTenantIdAndPocIdAndTestResultAndUpdatedAtBetween(any(),
-            any(), anyShort(), any(), any())).thenReturn(Collections.singletonList(quickTestArchive));
-        List<QuickTestArchive> quickTestArchives =
+            any(), anyShort(), any(), any())).thenReturn(Collections.singletonList(() -> hashedGuid));
+        List<QuickTestArchiveView> quickTestArchives =
             quickTestArchiveService.findByTestResultAndUpdatedAtBetween(
                 new HashMap<>(),
                 null,
@@ -141,19 +143,8 @@ public class QuickTestArchiveServiceTest {
     }
 
 
-    private void checkResponse(QuickTestArchive expected, QuickTestArchive act) {
+    private void checkResponse(QuickTestArchive expected, QuickTestArchiveView act) {
         assertEquals(expected.getHashedGuid(), act.getHashedGuid());
-        assertEquals(expected.getLastName(), act.getLastName());
-        assertEquals(expected.getFirstName(), act.getFirstName());
-        assertEquals(expected.getEmail(), act.getEmail());
-        assertEquals(expected.getPhoneNumber(), act.getPhoneNumber());
-        assertEquals(expected.getSex(), act.getSex());
-        assertEquals(expected.getStreet(), act.getStreet());
-        assertEquals(expected.getHouseNumber(), act.getHouseNumber());
-        assertEquals(expected.getZipCode(), act.getZipCode());
-        assertEquals(expected.getCity(), act.getCity());
-        assertEquals(expected.getBirthday(), act.getBirthday());
-        assertEquals(expected.getTestResult(), act.getTestResult());
     }
 }
 


### PR DESCRIPTION
Use a projection to only select hashedGuid from database while querying for reports. 