### PR TITLE
fix: cleanup old tests in separate txs

### DIFF
--- a/src/main/java/app/coronawarn/quicktest/service/QuickTestDeletionService.java
+++ b/src/main/java/app/coronawarn/quicktest/service/QuickTestDeletionService.java
@@ -1,0 +1,102 @@
+/*-
+ * ---license-start
+ * Corona-Warn-App / cwa-quick-test-backend
+ * ---
+ * Copyright (C) 2021 T-Systems International GmbH and all other contributors
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package app.coronawarn.quicktest.service;
+
+import app.coronawarn.quicktest.domain.QuickTest;
+import app.coronawarn.quicktest.model.TestResult;
+import app.coronawarn.quicktest.model.quicktest.QuickTestResult;
+import app.coronawarn.quicktest.repository.QuickTestRepository;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class QuickTestDeletionService {
+
+    private final QuickTestRepository quickTestRepository;
+    private final TestResultService testResultService;
+
+    /**
+     * Handle a chunk of old tests to delete.
+     * Requires_New opens a new transaction and commits it after the method finishes.
+     *
+     * @param deleteTimestamp find all before
+     * @param chunkSize desired chunk size
+     * @param chunks amount of chunks
+     * @param i current chunk
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleChunk(LocalDateTime deleteTimestamp, int chunkSize, int chunks, int i) {
+        log.info("Deleting chunk {} of {}", i, chunks);
+
+        List<QuickTest> quickTestChunk = quickTestRepository.findAllByCreatedAtBeforeAndVersionIsGreaterThan(
+          deleteTimestamp,
+          0,
+          PageRequest.of(i - 1, chunkSize));
+
+        quickTestChunk.forEach(quickTest -> sendResultToTestResultServer(
+          quickTest.getTestResultServerHash(),
+          TestResult.FAILED.getValue(),
+          deleteTimestamp.toEpochSecond(ZoneOffset.UTC),
+          quickTest.getConfirmationCwa() != null ? quickTest.getConfirmationCwa() : false));
+
+        log.info("Set Status of quicktests on TRS. Deleting QuickTests in DB");
+
+        try {
+            quickTestRepository.deleteAll(quickTestChunk);
+            quickTestRepository.flush();
+        } catch (final Exception exception) {
+            log.warn("Could not delete chunk on db, trying to continue with the next chunk.");
+        }
+
+        log.info("Processing of chunk {} of {} finished.", i, chunks);
+    }
+
+    /**
+     * Send to TRS.
+     * @param testResultServerHash the hash
+     * @param result the result (short)
+     * @param sc samle colletion timestamp
+     * @param confirmationCwa if cwa requested
+     * @throws ResponseStatusException possible error
+     */
+    private void sendResultToTestResultServer(String testResultServerHash, short result, Long sc,
+                                              boolean confirmationCwa) throws ResponseStatusException {
+        if (confirmationCwa && testResultServerHash != null) {
+            log.info("Sending TestResult to TestResult-Server");
+            QuickTestResult quickTestResult = new QuickTestResult();
+            quickTestResult.setId(testResultServerHash);
+            quickTestResult.setResult(result);
+            quickTestResult.setSampleCollection(sc);
+            testResultService.createOrUpdateTestResult(quickTestResult);
+            log.info("Update TestResult on TestResult-Server successfully.");
+        }
+    }
+}

--- a/src/test/java/app/coronawarn/quicktest/service/QuickTestDeletionServiceTest.java
+++ b/src/test/java/app/coronawarn/quicktest/service/QuickTestDeletionServiceTest.java
@@ -1,0 +1,87 @@
+/*-
+ * ---license-start
+ * Corona-Warn-App / cwa-quick-test-backend
+ * ---
+ * Copyright (C) 2021 T-Systems International GmbH and all other contributors
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package app.coronawarn.quicktest.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import app.coronawarn.quicktest.config.QuickTestConfig;
+import app.coronawarn.quicktest.domain.QuickTest;
+import app.coronawarn.quicktest.model.quicktest.QuickTestResult;
+import app.coronawarn.quicktest.repository.QuickTestRepository;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@Slf4j
+@SpringBootTest
+class QuickTestDeletionServiceTest {
+
+    @InjectMocks
+    private QuickTestDeletionService underTest;
+
+    @Mock
+    private QuickTestRepository quickTestRepository;
+
+    @Mock
+    private TestResultService testResultService;
+
+
+    @Test
+    void removeAllBeforeTest() {
+        LocalDateTime now = ZonedDateTime.now().withNano(0).toLocalDateTime();
+        QuickTest quickTest = new QuickTest();
+        quickTest.setConfirmationCwa(true);
+        quickTest.setTestResultServerHash("");
+        quickTest.setTestResult((short) 8);
+        quickTest.setUpdatedAt(now);
+
+        QuickTest quickTest1 = new QuickTest();
+        quickTest1.setConfirmationCwa(false);
+        quickTest1.setTestResultServerHash("");
+        quickTest1.setTestResult((short) 8);
+        quickTest1.setUpdatedAt(now);
+
+
+        QuickTestResult quickTestResult = new QuickTestResult();
+        quickTestResult.setId(quickTest.getTestResultServerHash());
+        quickTestResult.setResult(quickTest.getTestResult());
+        quickTestResult.setSampleCollection(quickTest.getUpdatedAt().toEpochSecond(ZoneOffset.UTC));
+
+        QuickTestConfig.CleanUpSettings cleanUpSettings = new QuickTestConfig.CleanUpSettings();
+        cleanUpSettings.setChunkSize(1000);
+
+        when(quickTestRepository.findAllByCreatedAtBeforeAndVersionIsGreaterThan(eq(now), eq(0), any()))
+          .thenReturn(Arrays.asList(quickTest, quickTest, quickTest1));
+        underTest.handleChunk(now, cleanUpSettings.getChunkSize(), 1, 1);
+        verify(quickTestRepository, times(1)).findAllByCreatedAtBeforeAndVersionIsGreaterThan(eq(now), eq(0), any());
+        verify(testResultService, times(2)).createOrUpdateTestResult(quickTestResult);
+    }
+}

--- a/src/test/java/app/coronawarn/quicktest/service/QuickTestServiceTest.java
+++ b/src/test/java/app/coronawarn/quicktest/service/QuickTestServiceTest.java
@@ -79,6 +79,8 @@ public class QuickTestServiceTest {
     private QuickTestLogRepository quickTestLogRepository;
     @Mock
     private TestResultService testResultService;
+    @Mock
+    private QuickTestDeletionService quickTestDeletionService;
 
     @Mock
     private PdfGenerator pdf;
@@ -333,8 +335,7 @@ public class QuickTestServiceTest {
             .thenReturn(Arrays.asList(quickTest, quickTest, quickTest1));
         when(quickTestConfig.getCleanUpSettings()).thenReturn(cleanUpSettings);
         quickTestService.removeAllBefore(now);
-        verify(quickTestRepository, times(1)).findAllByCreatedAtBeforeAndVersionIsGreaterThan(eq(now), eq(0), any());
-        verify(testResultService, times(2)).createOrUpdateTestResult(quickTestResult);
+        verify(quickTestDeletionService, times(1)).handleChunk(eq(now), eq(1000), eq(1), eq(1));
         verify(quickTestRepository, times(1)).deleteByCreatedAtBefore(now);
     }
 


### PR DESCRIPTION
The deletion of already processed chunks of tests should not be rolled back in case of an error. Chunks must be commited immediately.