### PR TITLE
feat: poc nat permissions

### DIFF
--- a/src/main/java/app/coronawarn/quicktest/config/QuickTestConfig.java
+++ b/src/main/java/app/coronawarn/quicktest/config/QuickTestConfig.java
@@ -42,6 +42,7 @@ public class QuickTestConfig {
     private String groupInformationDelimiter;
     private String dbEncryptionKey;
     private String labId;
+    private String pcrEnabledKey;
 
     private FrontendContextConfig frontendContextConfig = new FrontendContextConfig();
 

--- a/src/main/java/app/coronawarn/quicktest/config/SecurityConfig.java
+++ b/src/main/java/app/coronawarn/quicktest/config/SecurityConfig.java
@@ -49,6 +49,7 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
     public static final String ROLE_COUNTER = "ROLE_c19_quick_test_counter";
     public static final String ROLE_ADMIN = "ROLE_c19_quick_test_admin";
     public static final String ROLE_TENANT_COUNTER = "ROLE_c19_quick_tenant_test_counter";
+    public static final String ROLE_POC_NAT_ADMIN = "ROLE_c19_quick_test_poc_nat_admin";
 
     private static final String API_ROUTE = "/api/**";
     private static final String CONFIG_ROUTE = "/api/config/*";

--- a/src/main/java/app/coronawarn/quicktest/controller/GroupManagementController.java
+++ b/src/main/java/app/coronawarn/quicktest/controller/GroupManagementController.java
@@ -210,6 +210,7 @@ public class GroupManagementController {
         utils.checkRealm(token);
         GroupRepresentation userRootGroup = utils.checkUserRootGroup();
         utils.checkGroupIsInSubgroups(userRootGroup, id);
+        utils.checkPermissionsBasedOnInput(token, body);
 
         try {
             keycloakService.updateGroup(body);

--- a/src/main/java/app/coronawarn/quicktest/controller/QuickTestController.java
+++ b/src/main/java/app/coronawarn/quicktest/controller/QuickTestController.java
@@ -241,8 +241,8 @@ public class QuickTestController {
             && quickTestPersonalDataRequest.getTestResultServerHash() == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
         }
-        if (TestTypeUtils.isPcr(quickTestPersonalDataRequest.getTestType())) {
-            utilities.checkPocNatPermission();
+        if (TestTypeUtils.isPcr(quickTestPersonalDataRequest.getTestType()) && !utilities.checkPocNatPermission()) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "User is not allowed to create PoC NAT tests.");
         }
         try {
             quickTestService.updateQuickTestWithPersonalData(

--- a/src/main/java/app/coronawarn/quicktest/controller/QuickTestController.java
+++ b/src/main/java/app/coronawarn/quicktest/controller/QuickTestController.java
@@ -32,6 +32,7 @@ import app.coronawarn.quicktest.model.quicktest.QuickTestResponseList;
 import app.coronawarn.quicktest.model.quicktest.QuickTestUpdateRequest;
 import app.coronawarn.quicktest.repository.QuicktestView;
 import app.coronawarn.quicktest.service.QuickTestService;
+import app.coronawarn.quicktest.utils.TestTypeUtils;
 import app.coronawarn.quicktest.utils.Utilities;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -239,6 +240,9 @@ public class QuickTestController {
         if (quickTestPersonalDataRequest.getConfirmationCwa()
             && quickTestPersonalDataRequest.getTestResultServerHash() == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
+        }
+        if (TestTypeUtils.isPcr(quickTestPersonalDataRequest.getTestType())) {
+            utilities.checkPocNatPermission();
         }
         try {
             quickTestService.updateQuickTestWithPersonalData(

--- a/src/main/java/app/coronawarn/quicktest/controller/UserManagementControllerUtils.java
+++ b/src/main/java/app/coronawarn/quicktest/controller/UserManagementControllerUtils.java
@@ -21,6 +21,8 @@
 package app.coronawarn.quicktest.controller;
 
 import app.coronawarn.quicktest.config.KeycloakAdminProperties;
+import app.coronawarn.quicktest.config.SecurityConfig;
+import app.coronawarn.quicktest.model.keycloak.KeycloakGroupDetails;
 import app.coronawarn.quicktest.model.keycloak.KeycloakGroupResponse;
 import app.coronawarn.quicktest.service.KeycloakService;
 import app.coronawarn.quicktest.utils.Utilities;
@@ -123,6 +125,17 @@ public class UserManagementControllerUtils {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Group is not within your subgroups");
         } else {
             return groupsMap.get(groupId);
+        }
+    }
+
+    protected void checkPermissionsBasedOnInput(KeycloakAuthenticationToken token, KeycloakGroupDetails details)
+        throws ResponseStatusException {
+        if (details.getEnablePcr() != null && details.getEnablePcr()) {
+            boolean hasRolePocNatAdmin = token.getAuthorities().stream()
+                    .anyMatch(role -> role.getAuthority().equals(SecurityConfig.ROLE_POC_NAT_ADMIN));
+            if (!hasRolePocNatAdmin) {
+                throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Not allowed to enable PocNat");
+            }
         }
     }
 }

--- a/src/main/java/app/coronawarn/quicktest/model/quicktest/QuickTestPersonalDataRequest.java
+++ b/src/main/java/app/coronawarn/quicktest/model/quicktest/QuickTestPersonalDataRequest.java
@@ -102,7 +102,7 @@ public class QuickTestPersonalDataRequest {
     @NotNull
     @ValidCommonCharAndNumber
     private String diseaseAgentTargeted;
-
+    
     @ValidGuid
     private String testResultServerHash;
 

--- a/src/main/java/app/coronawarn/quicktest/utils/Utilities.java
+++ b/src/main/java/app/coronawarn/quicktest/utils/Utilities.java
@@ -242,4 +242,25 @@ public class Utilities {
         }
         return information;
     }
+
+    /**
+     * Check the Token for pcr_enabled flag.
+     */
+    public void checkPocNatPermission() {
+        Principal principal = getPrincipal();
+        boolean pcrEnabled = false;
+        if (principal instanceof KeycloakPrincipal) {
+            KeycloakPrincipal keycloakPrincipal = (KeycloakPrincipal) principal;
+            IDToken token = keycloakPrincipal.getKeycloakSecurityContext().getToken();
+            Map<String, Object> customClaims = token.getOtherClaims();
+
+            if (customClaims.containsKey(quickTestConfig.getPcrEnabledKey())) {
+                pcrEnabled = Boolean.parseBoolean(String.valueOf(customClaims.get(quickTestConfig.getPcrEnabledKey())));
+            }
+        }
+        if (!pcrEnabled) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                    "User is not allowed to create PoC NAT tests.");
+        }
+    }
 }

--- a/src/main/java/app/coronawarn/quicktest/utils/Utilities.java
+++ b/src/main/java/app/coronawarn/quicktest/utils/Utilities.java
@@ -178,9 +178,7 @@ public class Utilities {
         Principal principal = getPrincipal();
 
         if (principal instanceof KeycloakPrincipal) {
-            KeycloakPrincipal keycloakPrincipal = (KeycloakPrincipal) principal;
-            IDToken token = keycloakPrincipal.getKeycloakSecurityContext().getToken();
-            Map<String, Object> customClaims = token.getOtherClaims();
+            Map<String, Object> customClaims = getCustomClaims((KeycloakPrincipal) principal);
 
             if (customClaims.containsKey(quickTestConfig.getPointOfCareInformationName())) {
                 information = String.valueOf(customClaims.get(quickTestConfig.getPointOfCareInformationName()));
@@ -228,9 +226,7 @@ public class Utilities {
         Principal principal = getPrincipal();
 
         if (principal instanceof KeycloakPrincipal) {
-            KeycloakPrincipal keycloakPrincipal = (KeycloakPrincipal) principal;
-            IDToken token = keycloakPrincipal.getKeycloakSecurityContext().getToken();
-            Map<String, Object> customClaims = token.getOtherClaims();
+            Map<String, Object> customClaims = getCustomClaims((KeycloakPrincipal) principal);
             if (customClaims.containsKey(quickTestConfig.getGroupKey())) {
                 information = String.valueOf(customClaims.get(quickTestConfig.getGroupKey()));
             }
@@ -246,21 +242,23 @@ public class Utilities {
     /**
      * Check the Token for pcr_enabled flag.
      */
-    public void checkPocNatPermission() {
+    public boolean checkPocNatPermission() {
         Principal principal = getPrincipal();
         boolean pcrEnabled = false;
         if (principal instanceof KeycloakPrincipal) {
-            KeycloakPrincipal keycloakPrincipal = (KeycloakPrincipal) principal;
-            IDToken token = keycloakPrincipal.getKeycloakSecurityContext().getToken();
-            Map<String, Object> customClaims = token.getOtherClaims();
+            Map<String, Object> customClaims = getCustomClaims((KeycloakPrincipal) principal);
 
             if (customClaims.containsKey(quickTestConfig.getPcrEnabledKey())) {
                 pcrEnabled = Boolean.parseBoolean(String.valueOf(customClaims.get(quickTestConfig.getPcrEnabledKey())));
             }
         }
-        if (!pcrEnabled) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN,
-                    "User is not allowed to create PoC NAT tests.");
-        }
+        return pcrEnabled;
     }
+
+    private Map<String, Object> getCustomClaims(KeycloakPrincipal principal) {
+        KeycloakPrincipal keycloakPrincipal = principal;
+        IDToken token = keycloakPrincipal.getKeycloakSecurityContext().getToken();
+        return token.getOtherClaims();
+    }
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -84,6 +84,7 @@ quicktest:
   tenantIdKey: tenantId
   groupKey: groups
   bsnrKey: bsnr
+  pcrEnabledKey: pcr_enabled
   tenantPointOfCareIdKey: pocId
   pointOfCareInformationName: poc_details
   pointOfCareInformationDelimiter: \,

--- a/src/test/java/app/coronawarn/quicktest/controller/GroupManagementControllerTest.java
+++ b/src/test/java/app/coronawarn/quicktest/controller/GroupManagementControllerTest.java
@@ -20,8 +20,7 @@
 
 package app.coronawarn.quicktest.controller;
 
-import static app.coronawarn.quicktest.config.SecurityConfig.ROLE_ADMIN;
-import static app.coronawarn.quicktest.config.SecurityConfig.ROLE_LAB;
+import static app.coronawarn.quicktest.config.SecurityConfig.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -611,6 +610,44 @@ class GroupManagementControllerTest extends ServletKeycloakAuthUnitTestingSuppor
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .content(objectMapper.writeValueAsString(groupDetails)))
             .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockKeycloakAuth(
+            authorities = ROLE_ADMIN,
+            claims = @OpenIdClaims(sub = userId)
+    )
+    void testUpdateSubgroupPocNat_WrongRole() throws Exception {
+        KeycloakGroupDetails groupDetails = new KeycloakGroupDetails();
+        groupDetails.setName(subGroup.getName());
+        groupDetails.setPocDetails("pocDetails");
+        groupDetails.setPocId("pocId");
+        groupDetails.setEnablePcr(true);
+
+        mockMvc().perform(MockMvcRequestBuilders
+                        .put("/api/usermanagement/groups/" + subGroupId)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content(objectMapper.writeValueAsString(groupDetails)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockKeycloakAuth(
+            authorities = { ROLE_ADMIN, ROLE_POC_NAT_ADMIN },
+            claims = @OpenIdClaims(sub = userId)
+    )
+    void testUpdateSubgroupPocNat_Success() throws Exception {
+        KeycloakGroupDetails groupDetails = new KeycloakGroupDetails();
+        groupDetails.setName(subGroup.getName());
+        groupDetails.setPocDetails("pocDetails");
+        groupDetails.setPocId("pocId");
+        groupDetails.setEnablePcr(true);
+
+        mockMvc().perform(MockMvcRequestBuilders
+                        .put("/api/usermanagement/groups/" + subGroupId)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content(objectMapper.writeValueAsString(groupDetails)))
+                .andExpect(status().isNoContent());
     }
 
     @Test

--- a/src/test/java/app/coronawarn/quicktest/controller/QuickTestControllerTest.java
+++ b/src/test/java/app/coronawarn/quicktest/controller/QuickTestControllerTest.java
@@ -26,8 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import app.coronawarn.quicktest.config.QuicktestKeycloakSpringBootConfigResolver;
@@ -866,6 +865,28 @@ class QuickTestControllerTest extends ServletKeycloakAuthUnitTestingSupport {
 
         quickTestPersonalDataRequest.setTestResultServerHash(testResultServerHash);
 
+        //test poc nat
+        String pocNatType = "LP6464-4";
+        quickTestPersonalDataRequest.setTestType(pocNatType);
+        when(utilities.checkPocNatPermission()).thenReturn(true);
+        mockMvc().with(authentication().authorities(ROLE_COUNTER)).perform(MockMvcRequestBuilders
+                        .put(API_BASE_PATH + "/6fa4dcec/personalData")
+                        .accept(MediaType.APPLICATION_JSON_VALUE)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content(gson.toJson(quickTestPersonalDataRequest)))
+                .andExpect(status().isNoContent());
+
+        quickTestPersonalDataRequest.setTestType(pocNatType);
+        when(utilities.checkPocNatPermission()).thenReturn(false);
+        mockMvc().with(authentication().authorities(ROLE_COUNTER)).perform(MockMvcRequestBuilders
+                        .put(API_BASE_PATH + "/6fa4dcec/personalData")
+                        .accept(MediaType.APPLICATION_JSON_VALUE)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content(gson.toJson(quickTestPersonalDataRequest)))
+                .andExpect(status().isForbidden());
+
+        quickTestPersonalDataRequest.setTestType(null);
+
         doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND))
             .when(quickTestService).updateQuickTestWithPersonalData(any(), any(), any());
         mockMvc().with(authentication().authorities(ROLE_COUNTER)).perform(MockMvcRequestBuilders
@@ -889,8 +910,6 @@ class QuickTestControllerTest extends ServletKeycloakAuthUnitTestingSupport {
             .andExpect(result -> assertTrue(result.getResolvedException() instanceof ResponseStatusException))
             .andExpect(result -> assertEquals("500 INTERNAL_SERVER_ERROR",
                 result.getResolvedException().getMessage()));
-
-
     }
 
     @Test

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -63,6 +63,7 @@ quicktest:
   pointOfCareIdName: poc_id
   tenantIdKey: tenantId
   groupKey: groups
+  pcrEnabledKey: pcr_enabled
   groupInformationDelimiter: \,
   tenantPointOfCareIdKey: pocId
   dbEncryptionKey: abcdefghjklmnopq


### PR DESCRIPTION
Add permission checks on required roles for editing keycloak groups and required flags while updating personal data with poc nat tests