### PR TITLE
Chore: Update SpringBoot to 2.6.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.5</version>
+        <version>2.6.6</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>app.coronawarn</groupId>


### PR DESCRIPTION
Update to SpringBoot 2.6.6 to mitigate https://tanzu.vmware.com/security/cve-2022-22965