### PR TITLE
Chore: Update CWA-Parent to 1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>app.coronawarn</groupId>
         <artifactId>cwa-parent</artifactId>
-        <version>1.1</version>
+        <version>1.2</version>
     </parent>
     <artifactId>cwa-quick-test-backend</artifactId>
     <version>1.0.0-SNAPSHOT</version>


### PR DESCRIPTION
### Update the parent pom (cwa-parent) to the last released version.
  
  This PR will update several dependencies within this project.
  Please do a full integration test before merging this PR.
  
  Also please have a look on the [Release Notes](https://github.com/corona-warn-app/cwa-parent/releases/tag/1.2) of this new CWA-Parent version.