### PR TITLE
Chore: Update CWA-Parent to 1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>app.coronawarn</groupId>
         <artifactId>cwa-parent</artifactId>
-        <version>1.3</version>
+        <version>1.4</version>
     </parent>
     <artifactId>cwa-quick-test-backend</artifactId>
     <version>1.0.0-SNAPSHOT</version>


### PR DESCRIPTION
### Update the parent pom (cwa-parent) to the last released version.
  
  This PR will update several dependencies within this project.
  Please do a full integration test before merging this PR.
  
  Also please have a look on the [Release Notes](https://github.com/corona-warn-app/cwa-parent/releases/tag/1.4) of this new CWA-Parent version.